### PR TITLE
Add GitHub Actions for test and lint

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     - name: Install dependencies
       run: go mod tidy

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,0 +1,36 @@
+name: Test and Lint
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Install dependencies
+      run: go mod tidy
+
+    - name: Run tests
+      run: go test -v ./...
+
+    - name: Run golint
+      run: go install golang.org/x/lint/golint@latest && golint ./...
+
+    - name: Run go vet
+      run: go vet ./...

--- a/clipmerge_test.go
+++ b/clipmerge_test.go
@@ -95,3 +95,21 @@ func TestWriteClipboard(t *testing.T) {
 	content, _ := clipboard.ReadAll()
 	assert.Equal(t, expectedContent, content)
 }
+
+func TestLint(t *testing.T) {
+	cmd := exec.Command("golint", "./...")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	assert.NoError(t, err, out.String())
+}
+
+func TestVet(t *testing.T) {
+	cmd := exec.Command("go", "vet", "./...")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	assert.NoError(t, err, out.String())
+}

--- a/clipmerge_test.go
+++ b/clipmerge_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/atotto/clipboard"

--- a/clipmerge_test.go
+++ b/clipmerge_test.go
@@ -27,7 +27,10 @@ func TestMainFunction(t *testing.T) {
 	main()
 
 	// Verify
-	updatedClipboard, _ := clipboard.ReadAll()
+	updatedClipboard, err := clipboard.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to read clipboard content: %v", err)
+	}
 	expectedClipboard := "template content\n\n----\ncurrent clipboard content\n----"
 	assert.Equal(t, expectedClipboard, updatedClipboard)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/kyoshidajp/clipmerge
 
-go 1.16
+go 1.17
 
-require (
-	github.com/atotto/clipboard v0.1.2
-)
+require github.com/atotto/clipboard v0.1.2
+
+require github.com/stretchr/testify v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,10 @@ go 1.17
 
 require github.com/atotto/clipboard v0.1.2
 
-require github.com/stretchr/testify v1.10.0 // indirect
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
Add GitHub Actions workflow to run tests and linting on push and pull request events.

* **clipmerge_test.go**
  - Add `TestLint` function to run `golint` on the codebase.
  - Add `TestVet` function to run `go vet` on the codebase.

* **.github/workflows/test-and-lint.yml**
  - Create a new GitHub Actions workflow file.
  - Define a job to run on `push` and `pull_request` events.
  - Add steps to set up Go, install dependencies, run tests, and run linters.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kyoshidajp/clipmerge/pull/3?shareId=85533c67-ca9e-4789-bc1a-5f9f9257ddbe).