### PR TITLE
Release for v0.0.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Get version from tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist
+          GOOS=darwin GOARCH=amd64 go build -o dist/clipmerge_darwin_amd64
+          GOOS=darwin GOARCH=arm64 go build -o dist/clipmerge_darwin_arm64
+          GOOS=linux GOARCH=amd64 go build -o dist/clipmerge_linux_amd64
+          GOOS=linux GOARCH=arm64 go build -o dist/clipmerge_linux_arm64
+
+      - name: Archive binaries
+        run: |
+          cd dist
+          tar -czvf clipmerge_darwin_amd64.tar.gz clipmerge_darwin_amd64
+          tar -czvf clipmerge_darwin_arm64.tar.gz clipmerge_darwin_arm64
+          tar -czvf clipmerge_linux_amd64.tar.gz clipmerge_linux_amd64
+          tar -czvf clipmerge_linux_arm64.tar.gz clipmerge_linux_arm64
+          cd ..
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/clipmerge_darwin_amd64.tar.gz
+            dist/clipmerge_darwin_arm64.tar.gz
+            dist/clipmerge_linux_amd64.tar.gz
+            dist/clipmerge_linux_arm64.tar.gz
+          tag_name: ${{ env.VERSION }}
+          release_name: Release ${{ env.VERSION }}
+          draft: false
+          prerelease: false

--- a/.github/workflowstagpr.yml
+++ b/.github/workflowstagpr.yml
@@ -1,0 +1,18 @@
+name: Tagpr
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run tagpr
+        uses: Songmu/tagpr@v1

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,48 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.template (Optional)
+#       Pull request template file in go template format
+#
+#   tagpr.templateText (Optional)
+#       Pull request template text in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+#   tagpr.commitPrefix (Optional)
+#       Prefix of commit message. Default is "[tagpr]"
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [v0.0.1](https://github.com/kyoshidajp/clipmerge/commits/v0.0.1) - 2025-03-09
+- Port clipmerge.sh to Go language by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/1
+- Translate messages from Japanese to English by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/2


### PR DESCRIPTION
This pull request is for the next release as v0.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* Port clipmerge.sh to Go language by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/1
* Translate messages from Japanese to English by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/2

## New Contributors
* @kyoshidajp made their first contribution in https://github.com/kyoshidajp/clipmerge/pull/1

**Full Changelog**: https://github.com/kyoshidajp/clipmerge/commits/v0.0.1