### PR TITLE
Release for v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [v0.0.1](https://github.com/kyoshidajp/clipmerge/commits/v0.0.1) - 2025-03-09
 - Port clipmerge.sh to Go language by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/1
 - Translate messages from Japanese to English by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/2
+
+## [v0.0.1](https://github.com/kyoshidajp/clipmerge/commits/v0.0.1) - 2025-03-09
+- Port clipmerge.sh to Go language by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/1
+- Translate messages from Japanese to English by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/2


### PR DESCRIPTION
This pull request is for the next release as v0.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Port clipmerge.sh to Go language by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/1
* Translate messages from Japanese to English by @kyoshidajp in https://github.com/kyoshidajp/clipmerge/pull/2

## New Contributors
* @kyoshidajp made their first contribution in https://github.com/kyoshidajp/clipmerge/pull/1

**Full Changelog**: https://github.com/kyoshidajp/clipmerge/commits/v0.0.1